### PR TITLE
implement bulk loading

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,8 @@
 {
     "cSpell.words": [
+        "imerge",
+        "neighbouring",
+        "nmerge",
         "segmenttree",
         "stretchr",
         "structs"

--- a/segmenttree/aggregate.go
+++ b/segmenttree/aggregate.go
@@ -1,0 +1,8 @@
+package segmenttree
+
+type Aggregate struct {
+	operation        func(Addable, Addable) Addable
+	inverseOperation func(Addable, Addable) Addable
+	additionElement  func(Addable) Addable
+	neutralElement   Addable
+}

--- a/segmenttree/bulk_util.go
+++ b/segmenttree/bulk_util.go
@@ -1,0 +1,48 @@
+package segmenttree
+
+func createAndSortValueTimeTuples(aggregate Aggregate, values []ValueIntervalTuple) []ValueTimeTuple {
+	result := make([]ValueTimeTuple, 0, 2*len(values))
+
+	for _, value := range values {
+		positiveTuple := ValueTimeTuple{
+			value: value.value,
+			time:  value.interval.start,
+		}
+
+		negativeTuple := ValueTimeTuple{
+			value: aggregate.inverseOperation(aggregate.neutralElement, value.value),
+			time:  value.interval.end,
+		}
+
+		result = insertInOrder(aggregate, positiveTuple, result)
+		result = insertInOrder(aggregate, negativeTuple, result)
+	}
+
+	return result
+}
+
+func insertInOrder(aggregate Aggregate, toInsert ValueTimeTuple, values []ValueTimeTuple) []ValueTimeTuple {
+	for i := 0; i < len(values); i++ {
+		if toInsert.time > values[i].time {
+			continue
+		} else if toInsert.time == values[i].time {
+			additionResult := aggregate.operation(toInsert.value, values[i].value)
+
+			if additionResult == aggregate.neutralElement {
+				// Remove element
+				return append(values[:i], values[i+1:]...)
+			} else {
+				// Replace existing element with combined element
+				values[i] = ValueTimeTuple{value: additionResult, time: toInsert.time}
+				return values
+			}
+		} else {
+			// Insert element
+			values = append(values[:i+1], values[i:]...)
+			values[i] = toInsert
+			return values
+		}
+	}
+
+	return append(values, toInsert)
+}

--- a/segmenttree/bulk_util_test.go
+++ b/segmenttree/bulk_util_test.go
@@ -1,0 +1,148 @@
+package segmenttree
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInsertSortedWhenSortedAscending(t *testing.T) {
+	// Arrange
+	aggregate := Aggregate{Sum, InverseSum, Identity, Float(0)}
+	list := make([]ValueTimeTuple, 0, 10)
+
+	// Act
+	list = insertInOrder(aggregate, ValueTimeTuple{value: Float(1), time: 1}, list)
+	list = insertInOrder(aggregate, ValueTimeTuple{value: Float(2), time: 2}, list)
+	list = insertInOrder(aggregate, ValueTimeTuple{value: Float(3), time: 3}, list)
+	list = insertInOrder(aggregate, ValueTimeTuple{value: Float(4), time: 4}, list)
+	list = insertInOrder(aggregate, ValueTimeTuple{value: Float(5), time: 5}, list)
+	list = insertInOrder(aggregate, ValueTimeTuple{value: Float(6), time: 6}, list)
+
+	// Assert
+	assert.Len(t, list, 6)
+	assert.Equal(t, Float(1), list[0].value)
+	assert.Equal(t, Float(2), list[1].value)
+	assert.Equal(t, Float(3), list[2].value)
+	assert.Equal(t, Float(4), list[3].value)
+	assert.Equal(t, Float(5), list[4].value)
+	assert.Equal(t, Float(6), list[5].value)
+}
+
+func TestInsertSortedWhenSortedDescending(t *testing.T) {
+	// Arrange
+	aggregate := Aggregate{Sum, InverseSum, Identity, Float(0)}
+	list := make([]ValueTimeTuple, 0, 10)
+
+	// Act
+	list = insertInOrder(aggregate, ValueTimeTuple{value: Float(6), time: 6}, list)
+	list = insertInOrder(aggregate, ValueTimeTuple{value: Float(5), time: 5}, list)
+	list = insertInOrder(aggregate, ValueTimeTuple{value: Float(4), time: 4}, list)
+	list = insertInOrder(aggregate, ValueTimeTuple{value: Float(3), time: 3}, list)
+	list = insertInOrder(aggregate, ValueTimeTuple{value: Float(2), time: 2}, list)
+	list = insertInOrder(aggregate, ValueTimeTuple{value: Float(1), time: 1}, list)
+
+	// Assert
+	assert.Len(t, list, 6)
+	assert.Equal(t, Float(1), list[0].value)
+	assert.Equal(t, Float(2), list[1].value)
+	assert.Equal(t, Float(3), list[2].value)
+	assert.Equal(t, Float(4), list[3].value)
+	assert.Equal(t, Float(5), list[4].value)
+	assert.Equal(t, Float(6), list[5].value)
+}
+
+func TestInsertSortedWhenRandomOrder(t *testing.T) {
+	// Arrange
+	aggregate := Aggregate{Sum, InverseSum, Identity, Float(0)}
+	list := make([]ValueTimeTuple, 0, 6)
+
+	// Act
+	list = insertInOrder(aggregate, ValueTimeTuple{value: Float(6), time: 6}, list)
+	list = insertInOrder(aggregate, ValueTimeTuple{value: Float(1), time: 1}, list)
+	list = insertInOrder(aggregate, ValueTimeTuple{value: Float(4), time: 4}, list)
+	list = insertInOrder(aggregate, ValueTimeTuple{value: Float(5), time: 5}, list)
+	list = insertInOrder(aggregate, ValueTimeTuple{value: Float(3), time: 3}, list)
+	list = insertInOrder(aggregate, ValueTimeTuple{value: Float(2), time: 2}, list)
+
+	// Assert
+	assert.Len(t, list, 6)
+	assert.Equal(t, Float(1), list[0].value)
+	assert.Equal(t, Float(2), list[1].value)
+	assert.Equal(t, Float(3), list[2].value)
+	assert.Equal(t, Float(4), list[3].value)
+	assert.Equal(t, Float(5), list[4].value)
+	assert.Equal(t, Float(6), list[5].value)
+}
+
+func TestInsertSortedWhenMerge(t *testing.T) {
+	// Arrange
+	aggregate := Aggregate{Sum, InverseSum, Identity, Float(0)}
+	list := make([]ValueTimeTuple, 0, 6)
+
+	// Act
+	list = insertInOrder(aggregate, ValueTimeTuple{value: Float(1), time: 1}, list)
+	list = insertInOrder(aggregate, ValueTimeTuple{value: Float(2), time: 2}, list)
+	list = insertInOrder(aggregate, ValueTimeTuple{value: Float(3), time: 3}, list) // will be merged
+	list = insertInOrder(aggregate, ValueTimeTuple{value: Float(4), time: 3}, list) // will be merged
+	list = insertInOrder(aggregate, ValueTimeTuple{value: Float(5), time: 5}, list)
+	list = insertInOrder(aggregate, ValueTimeTuple{value: Float(6), time: 6}, list)
+
+	// Assert
+	assert.Len(t, list, 5)
+	assert.Equal(t, Float(1), list[0].value)
+	assert.Equal(t, Float(2), list[1].value)
+	assert.Equal(t, Float(7), list[2].value)
+	assert.Equal(t, Float(5), list[3].value)
+	assert.Equal(t, Float(6), list[4].value)
+}
+
+func TestInsertSortedWhenInverse(t *testing.T) {
+	// Arrange
+	aggregate := Aggregate{Sum, InverseSum, Identity, Float(0)}
+	list := make([]ValueTimeTuple, 0, 6)
+
+	// Act
+	list = insertInOrder(aggregate, ValueTimeTuple{value: Float(1), time: 1}, list)
+	list = insertInOrder(aggregate, ValueTimeTuple{value: Float(2), time: 2}, list)
+	list = insertInOrder(aggregate, ValueTimeTuple{value: Float(3), time: 3}, list)  // will be removed
+	list = insertInOrder(aggregate, ValueTimeTuple{value: Float(-3), time: 3}, list) // will be removed
+	list = insertInOrder(aggregate, ValueTimeTuple{value: Float(5), time: 5}, list)
+	list = insertInOrder(aggregate, ValueTimeTuple{value: Float(6), time: 6}, list)
+
+	// Assert
+	assert.Len(t, list, 4)
+	assert.Equal(t, Float(1), list[0].value)
+	assert.Equal(t, Float(2), list[1].value)
+	assert.Equal(t, Float(5), list[2].value)
+	assert.Equal(t, Float(6), list[3].value)
+}
+
+func TestSplitAndSort(t *testing.T) {
+	// Arrange
+	aggregate := Aggregate{Sum, InverseSum, Identity, Float(0)}
+
+	var testData []ValueIntervalTuple = []ValueIntervalTuple{
+		{interval: NewInterval(10, 40), value: Float(2)},
+		{interval: NewInterval(10, 30), value: Float(3)},
+		{interval: NewInterval(20, 40), value: Float(1)},
+		{interval: NewInterval(5, 15), value: Float(2)},
+		{interval: NewInterval(35, 45), value: Float(4)},
+		{interval: NewInterval(10, 50), value: Float(1)},
+	}
+
+	// Act
+	result := createAndSortValueTimeTuples(aggregate, testData)
+
+	// Assert
+	assert.Len(t, result, 9)
+	assert.Equal(t, ValueTimeTuple{time: 5, value: Float(2)}, result[0])
+	assert.Equal(t, ValueTimeTuple{time: 10, value: Float(6)}, result[1])
+	assert.Equal(t, ValueTimeTuple{time: 15, value: Float(-2)}, result[2])
+	assert.Equal(t, ValueTimeTuple{time: 20, value: Float(1)}, result[3])
+	assert.Equal(t, ValueTimeTuple{time: 30, value: Float(-3)}, result[4])
+	assert.Equal(t, ValueTimeTuple{time: 35, value: Float(4)}, result[5])
+	assert.Equal(t, ValueTimeTuple{time: 40, value: Float(-3)}, result[6])
+	assert.Equal(t, ValueTimeTuple{time: 45, value: Float(-4)}, result[7])
+	assert.Equal(t, ValueTimeTuple{time: 50, value: Float(-1)}, result[8])
+}

--- a/segmenttree/node.go
+++ b/segmenttree/node.go
@@ -269,6 +269,24 @@ func (node *Node) split() {
 	}
 }
 
+func (node *Node) insertTuple(key uint32, value Addable) {
+	// This function should only be used when bulk inserting
+	// into a tree.
+	// Assumes that sorted continuous key/value pairs are inserted
+	// at the rightmost part of the tree.
+	if node.isLeaf {
+		node.keys = append(node.keys, key)
+		node.values = append(node.values, value)
+
+		if node.size()+1 > node.tree.branchingFactor {
+			node.split()
+		}
+	} else {
+		lastChild := node.children[len(node.children)-1]
+		lastChild.insertTuple(key, value)
+	}
+}
+
 func (node *Node) size() uint32 {
 	return uint32(len(node.keys))
 }

--- a/segmenttree/node_test.go
+++ b/segmenttree/node_test.go
@@ -219,7 +219,7 @@ func TestInsertEmptyNode(t *testing.T) {
 		keys:   []uint32{},
 		values: []Addable{Float(0)},
 		tree: &SegmentTreeImpl{
-			aggregate:       Aggregate{Sum, Identity, Float(0)},
+			aggregate:       Aggregate{Sum, InverseSum, Identity, Float(0)},
 			branchingFactor: BRANCHING_FACTOR,
 		},
 	}
@@ -240,7 +240,7 @@ func TestInsertEmptyNode(t *testing.T) {
 func TestInsertSelfContained1(t *testing.T) {
 	// Arrange
 	tree := &SegmentTreeImpl{
-		aggregate:       Aggregate{Sum, Identity, Float(0)},
+		aggregate:       Aggregate{Sum, InverseSum, Identity, Float(0)},
 		branchingFactor: BRANCHING_FACTOR,
 	}
 	node := &Node{
@@ -277,7 +277,7 @@ func TestInsertSelfContained1(t *testing.T) {
 func TestInsertSelfContained2(t *testing.T) {
 	// Arrange
 	tree := &SegmentTreeImpl{
-		aggregate:       Aggregate{Sum, Identity, Float(0)},
+		aggregate:       Aggregate{Sum, InverseSum, Identity, Float(0)},
 		branchingFactor: BRANCHING_FACTOR,
 	}
 	node := &Node{
@@ -314,7 +314,7 @@ func TestInsertSelfContained2(t *testing.T) {
 func TestInsertSelfContained3(t *testing.T) {
 	// Arrange
 	tree := &SegmentTreeImpl{
-		aggregate:       Aggregate{Sum, Identity, Float(0)},
+		aggregate:       Aggregate{Sum, InverseSum, Identity, Float(0)},
 		branchingFactor: BRANCHING_FACTOR,
 	}
 	node := &Node{
@@ -351,7 +351,7 @@ func TestInsertSelfContained3(t *testing.T) {
 func TestInsertNodeIntervalLeftLarger1(t *testing.T) {
 	// Arrange
 	tree := &SegmentTreeImpl{
-		aggregate:       Aggregate{Sum, Identity, Float(0)},
+		aggregate:       Aggregate{Sum, InverseSum, Identity, Float(0)},
 		branchingFactor: BRANCHING_FACTOR,
 	}
 	node := &Node{
@@ -386,7 +386,7 @@ func TestInsertNodeIntervalLeftLarger1(t *testing.T) {
 func TestInsertNodeIntervalLeftLarger2(t *testing.T) {
 	// Arrange
 	tree := &SegmentTreeImpl{
-		aggregate:       Aggregate{Sum, Identity, Float(0)},
+		aggregate:       Aggregate{Sum, InverseSum, Identity, Float(0)},
 		branchingFactor: BRANCHING_FACTOR,
 	}
 	node := &Node{
@@ -421,7 +421,7 @@ func TestInsertNodeIntervalLeftLarger2(t *testing.T) {
 func TestInsertNodeIntervalLeftLarger3(t *testing.T) {
 	// Arrange
 	tree := &SegmentTreeImpl{
-		aggregate:       Aggregate{Sum, Identity, Float(0)},
+		aggregate:       Aggregate{Sum, InverseSum, Identity, Float(0)},
 		branchingFactor: BRANCHING_FACTOR,
 	}
 	node := &Node{
@@ -456,7 +456,7 @@ func TestInsertNodeIntervalLeftLarger3(t *testing.T) {
 func TestInsertNodeIntervalRightLarger1(t *testing.T) {
 	// Arrange
 	tree := &SegmentTreeImpl{
-		aggregate:       Aggregate{Sum, Identity, Float(0)},
+		aggregate:       Aggregate{Sum, InverseSum, Identity, Float(0)},
 		branchingFactor: BRANCHING_FACTOR,
 	}
 	node := &Node{
@@ -491,7 +491,7 @@ func TestInsertNodeIntervalRightLarger1(t *testing.T) {
 func TestInsertNodeIntervalRightLarger2(t *testing.T) {
 	// Arrange
 	tree := &SegmentTreeImpl{
-		aggregate:       Aggregate{Sum, Identity, Float(0)},
+		aggregate:       Aggregate{Sum, InverseSum, Identity, Float(0)},
 		branchingFactor: BRANCHING_FACTOR,
 	}
 	node := &Node{
@@ -526,7 +526,7 @@ func TestInsertNodeIntervalRightLarger2(t *testing.T) {
 func TestInsertNodeIntervalRightLarger3(t *testing.T) {
 	// Arrange
 	tree := &SegmentTreeImpl{
-		aggregate:       Aggregate{Sum, Identity, Float(0)},
+		aggregate:       Aggregate{Sum, InverseSum, Identity, Float(0)},
 		branchingFactor: BRANCHING_FACTOR,
 	}
 	node := &Node{
@@ -564,7 +564,7 @@ func TestInsertMatchingStartPoint1(t *testing.T) {
 		keys:   []uint32{10, 40},
 		values: []Addable{Float(0), Float(2), Float(0)},
 		tree: &SegmentTreeImpl{
-			aggregate:       Aggregate{Sum, Identity, Float(0)},
+			aggregate:       Aggregate{Sum, InverseSum, Identity, Float(0)},
 			branchingFactor: BRANCHING_FACTOR,
 		},
 	}
@@ -589,7 +589,7 @@ func TestInsertMatchingStartPoint2IntervallIndex1(t *testing.T) {
 		keys:   []uint32{10, 40},
 		values: []Addable{Float(0), Float(2), Float(0)},
 		tree: &SegmentTreeImpl{
-			aggregate:       Aggregate{Sum, Identity, Float(0)},
+			aggregate:       Aggregate{Sum, InverseSum, Identity, Float(0)},
 			branchingFactor: BRANCHING_FACTOR,
 		},
 	}
@@ -614,7 +614,7 @@ func TestInsertMatchingStartPoint3(t *testing.T) {
 		keys:   []uint32{10, 40},
 		values: []Addable{Float(0), Float(2), Float(0)},
 		tree: &SegmentTreeImpl{
-			aggregate:       Aggregate{Sum, Identity, Float(0)},
+			aggregate:       Aggregate{Sum, InverseSum, Identity, Float(0)},
 			branchingFactor: BRANCHING_FACTOR,
 		},
 	}
@@ -639,7 +639,7 @@ func TestInsertMatchingEndPoint1(t *testing.T) {
 		keys:   []uint32{10, 40},
 		values: []Addable{Float(0), Float(2), Float(0)},
 		tree: &SegmentTreeImpl{
-			aggregate:       Aggregate{Sum, Identity, Float(0)},
+			aggregate:       Aggregate{Sum, InverseSum, Identity, Float(0)},
 			branchingFactor: BRANCHING_FACTOR,
 		},
 	}
@@ -664,7 +664,7 @@ func TestInsertMatchingEndPoint2(t *testing.T) {
 		keys:   []uint32{10, 40},
 		values: []Addable{Float(0), Float(2), Float(0)},
 		tree: &SegmentTreeImpl{
-			aggregate:       Aggregate{Sum, Identity, Float(0)},
+			aggregate:       Aggregate{Sum, InverseSum, Identity, Float(0)},
 			branchingFactor: BRANCHING_FACTOR,
 		},
 	}
@@ -689,7 +689,7 @@ func TestInsertMatchingEndPoint3(t *testing.T) {
 		keys:   []uint32{10, 40},
 		values: []Addable{Float(0), Float(2), Float(0)},
 		tree: &SegmentTreeImpl{
-			aggregate:       Aggregate{Sum, Identity, Float(0)},
+			aggregate:       Aggregate{Sum, InverseSum, Identity, Float(0)},
 			branchingFactor: BRANCHING_FACTOR,
 		},
 	}
@@ -711,7 +711,7 @@ func TestInsertMatchingEndPoint3(t *testing.T) {
 func TestSplitRootNodeWithOddNumberOfKeys(t *testing.T) {
 	// Arrange
 	SBTree := &SegmentTreeImpl{
-		aggregate:       Aggregate{Sum, Identity, Float(0)},
+		aggregate:       Aggregate{Sum, InverseSum, Identity, Float(0)},
 		branchingFactor: 4,
 	}
 	n0 := &Node{
@@ -757,7 +757,7 @@ func TestSplitRootNodeWithOddNumberOfKeys(t *testing.T) {
 func TestSplitRootNodeWithEvenNumberOfKeysBook(t *testing.T) {
 	// Arrange
 	SBTree := &SegmentTreeImpl{
-		aggregate:       Aggregate{Sum, Identity, Float(0)},
+		aggregate:       Aggregate{Sum, InverseSum, Identity, Float(0)},
 		branchingFactor: 4,
 	}
 	n0 := &Node{
@@ -799,7 +799,7 @@ func TestSplitRootNodeWithEvenNumberOfKeysBook(t *testing.T) {
 func TestSplitNonRootNodeIsLeafAndSplitsNotParent(t *testing.T) {
 	// Arrange
 	SBTree := &SegmentTreeImpl{
-		aggregate:       Aggregate{Sum, Identity, Float(0)},
+		aggregate:       Aggregate{Sum, InverseSum, Identity, Float(0)},
 		branchingFactor: 4,
 	}
 	n0 := &Node{
@@ -882,7 +882,7 @@ func TestSplitNonRootNodeIsLeafAndSplitsNotParent(t *testing.T) {
 func TestSplitMostRightNonRootNodeIsLeafAndSplitsNotParent(t *testing.T) {
 	// Arrange
 	SBTree := &SegmentTreeImpl{
-		aggregate:       Aggregate{Sum, Identity, Float(0)},
+		aggregate:       Aggregate{Sum, InverseSum, Identity, Float(0)},
 		branchingFactor: 4,
 	}
 	n0 := &Node{
@@ -963,7 +963,7 @@ func TestSplitMostRightNonRootNodeIsLeafAndSplitsNotParent(t *testing.T) {
 func TestSplitMostLefNonRootNodeIsLeafAndSplitsNotParent(t *testing.T) {
 	// Arrange
 	SBTree := &SegmentTreeImpl{
-		aggregate:       Aggregate{Sum, Identity, Float(0)},
+		aggregate:       Aggregate{Sum, InverseSum, Identity, Float(0)},
 		branchingFactor: 4,
 	}
 	n0 := &Node{
@@ -1027,7 +1027,7 @@ func TestSplitMostLefNonRootNodeIsLeafAndSplitsNotParent(t *testing.T) {
 func TestSplitNonRootNodeIsLeafAndSplitsParentWhichIsNoLeaf(t *testing.T) {
 	// Arrange
 	SBTree := &SegmentTreeImpl{
-		aggregate:       Aggregate{Sum, Identity, Float(0)},
+		aggregate:       Aggregate{Sum, InverseSum, Identity, Float(0)},
 		branchingFactor: 4,
 	}
 	n0 := &Node{
@@ -1136,7 +1136,7 @@ func TestIMergeOnlyOneKeyMergeTwoValues(t *testing.T) {
 		values: []Addable{Float(8), Float(8)},
 		isLeaf: true,
 		tree: &SegmentTreeImpl{
-			aggregate:       Aggregate{Sum, Identity, Float(0)},
+			aggregate:       Aggregate{Sum, InverseSum, Identity, Float(0)},
 			branchingFactor: BRANCHING_FACTOR,
 		},
 	}
@@ -1156,7 +1156,7 @@ func TestIMergeOnlyTwoKeysMergeTwoValues(t *testing.T) {
 		values: []Addable{Float(0), Float(2), Float(2)},
 		isLeaf: true,
 		tree: &SegmentTreeImpl{
-			aggregate:       Aggregate{Sum, Identity, Float(0)},
+			aggregate:       Aggregate{Sum, InverseSum, Identity, Float(0)},
 			branchingFactor: BRANCHING_FACTOR,
 		},
 	}
@@ -1174,7 +1174,7 @@ func TestIMergeOnlyTwoKeysMergeTwoValues(t *testing.T) {
 func TestNMerge(t *testing.T) {
 	// Arrange
 	tree := &SegmentTreeImpl{
-		aggregate:       Aggregate{Sum, Identity, Float(0)},
+		aggregate:       Aggregate{Sum, InverseSum, Identity, Float(0)},
 		branchingFactor: BRANCHING_FACTOR,
 	}
 	n0 := &Node{

--- a/segmenttree/operations.go
+++ b/segmenttree/operations.go
@@ -1,5 +1,7 @@
 package segmenttree
 
+import "math"
+
 func Sum(x Addable, y Addable) Addable {
 	return x.Add(y)
 }
@@ -55,6 +57,7 @@ type Addable interface {
 	Add(x Addable) Addable
 	Inverse() Addable
 	Subtract(x Addable) Addable
+	AsFloat64() float64
 }
 
 type AverageTuple struct {
@@ -82,6 +85,14 @@ func (x AverageTuple) Inverse() Addable {
 	}
 }
 
+func (x AverageTuple) AsFloat64() float64 {
+	if x.Count == 0 {
+		return math.NaN()
+	}
+
+	return float64(x.Sum) / float64(x.Count)
+}
+
 type Float float32
 
 func (x Float) Add(y Addable) Addable {
@@ -94,6 +105,10 @@ func (x Float) Inverse() Addable {
 
 func (x Float) Subtract(y Addable) Addable {
 	return x - y.(Float)
+}
+
+func (x Float) AsFloat64() float64 {
+	return float64(x)
 }
 
 func (x Float) Compare(y Float) int {

--- a/segmenttree/operations.go
+++ b/segmenttree/operations.go
@@ -4,12 +4,24 @@ func Sum(x Addable, y Addable) Addable {
 	return x.Add(y)
 }
 
+func InverseSum(x Addable, y Addable) Addable {
+	return x.Subtract(y)
+}
+
 func Count(x Addable, y Addable) Addable {
 	return x.Add(y)
 }
 
+func InverseCount(x Addable, y Addable) Addable {
+	return x.Subtract(y)
+}
+
 func Average(x Addable, y Addable) Addable {
 	return x.Add(y)
+}
+
+func InverseAverage(x Addable, y Addable) Addable {
+	return x.Subtract(y)
 }
 
 func Min(x Comparable, y Comparable) Comparable {
@@ -42,6 +54,7 @@ type Comparable interface {
 type Addable interface {
 	Add(x Addable) Addable
 	Inverse() Addable
+	Subtract(x Addable) Addable
 }
 
 type AverageTuple struct {
@@ -49,13 +62,20 @@ type AverageTuple struct {
 	Count int
 }
 
-func (x AverageTuple) Add(y AverageTuple) AverageTuple {
+func (x AverageTuple) Add(y Addable) Addable {
 	return AverageTuple{
-		Sum:   x.Sum + y.Sum,
-		Count: x.Count + y.Count,
+		Sum:   x.Sum + y.(AverageTuple).Sum,
+		Count: x.Count + y.(AverageTuple).Count,
 	}
 }
-func (x AverageTuple) Inverse() AverageTuple {
+
+func (x AverageTuple) Subtract(y Addable) Addable {
+	return AverageTuple{
+		Sum:   x.Sum - y.(AverageTuple).Sum,
+		Count: x.Count - y.(AverageTuple).Count,
+	}
+}
+func (x AverageTuple) Inverse() Addable {
 	return AverageTuple{
 		Sum:   -x.Sum,
 		Count: -1,
@@ -70,6 +90,10 @@ func (x Float) Add(y Addable) Addable {
 
 func (x Float) Inverse() Addable {
 	return -x
+}
+
+func (x Float) Subtract(y Addable) Addable {
+	return x - y.(Float)
 }
 
 func (x Float) Compare(y Float) int {

--- a/segmenttree/segmenttree.go
+++ b/segmenttree/segmenttree.go
@@ -5,4 +5,5 @@ type SegmentTree interface {
 	GetWithinInterval(interval Interval) []ValueIntervalTuple
 	Insert(value ValueIntervalTuple)
 	Delete(value ValueIntervalTuple)
+	InsertRange(values []ValueIntervalTuple)
 }

--- a/segmenttree/segmenttree_test.go
+++ b/segmenttree/segmenttree_test.go
@@ -1,6 +1,7 @@
 package segmenttree
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -56,12 +57,34 @@ func TestGetWithinInterval(t *testing.T) {
 	assert.Contains(res, ValueIntervalTuple{value: Float(7), interval: Interval{start: 20, end: 28}})
 }
 
+func TestGetWithinIntervalWholeRange(t *testing.T) {
+	// Arrange
+	tree := setupTree()
+
+	// Act
+	result := tree.GetWithinInterval(Interval{start: 0, end: math.MaxUint32})
+
+	// Assert
+	assert.Len(t, result, 10)
+
+	assert.Equal(t, ValueIntervalTuple{interval: NewInterval(0, 5), value: Float(0)}, result[0])
+	assert.Equal(t, ValueIntervalTuple{interval: NewInterval(5, 10), value: Float(2)}, result[1])
+	assert.Equal(t, ValueIntervalTuple{interval: NewInterval(10, 15), value: Float(8)}, result[2])
+	assert.Equal(t, ValueIntervalTuple{interval: NewInterval(15, 20), value: Float(6)}, result[3])
+	assert.Equal(t, ValueIntervalTuple{interval: NewInterval(20, 30), value: Float(7)}, result[4])
+	assert.Equal(t, ValueIntervalTuple{interval: NewInterval(30, 35), value: Float(4)}, result[5])
+	assert.Equal(t, ValueIntervalTuple{interval: NewInterval(35, 40), value: Float(8)}, result[6])
+	assert.Equal(t, ValueIntervalTuple{interval: NewInterval(40, 45), value: Float(5)}, result[7])
+	assert.Equal(t, ValueIntervalTuple{interval: NewInterval(45, 50), value: Float(1)}, result[8])
+	assert.Equal(t, ValueIntervalTuple{interval: NewInterval(50, math.MaxUint32), value: Float(0)}, result[9])
+}
+
 func TestNewTree(t *testing.T) {
 	// Arrange
 	assert := assert.New(t)
 
 	// Act
-	tree := NewSegmentTree(BRANCHING_FACTOR, Aggregate{Sum, Identity, Float(0)})
+	tree := NewSegmentTree(BRANCHING_FACTOR, Aggregate{Sum, InverseSum, Identity, Float(0)})
 
 	// Assert
 	n0 := tree.root
@@ -247,7 +270,7 @@ func TestInsertTwiceSameRangeSimpleElement(t *testing.T) {
 	n0.parent = nil
 	tree := &SegmentTreeImpl{
 		root:            n0,
-		aggregate:       Aggregate{Sum, Identity, Float(0)},
+		aggregate:       Aggregate{Sum, InverseSum, Identity, Float(0)},
 		branchingFactor: BRANCHING_FACTOR,
 	}
 	n0.tree = tree
@@ -266,7 +289,7 @@ func TestInsertMatchingEndPoint4(t *testing.T) {
 		values: []Addable{Float(0), Float(5), Float(2), Float(0)},
 		isLeaf: true,
 		tree: &SegmentTreeImpl{
-			aggregate:       Aggregate{Sum, Identity, Float(0)},
+			aggregate:       Aggregate{Sum, InverseSum, Identity, Float(0)},
 			branchingFactor: BRANCHING_FACTOR,
 		},
 	}
@@ -387,7 +410,7 @@ func TestDelete2(t *testing.T) {
 
 	tree := &SegmentTreeImpl{
 		root:            n0,
-		aggregate:       Aggregate{Sum, Identity, Float(0)},
+		aggregate:       Aggregate{Sum, InverseSum, Identity, Float(0)},
 		branchingFactor: BRANCHING_FACTOR,
 	}
 
@@ -449,7 +472,7 @@ func TestDeleteSimpleElement(t *testing.T) {
 	n0.parent = nil
 	tree := &SegmentTreeImpl{
 		root:            n0,
-		aggregate:       Aggregate{Sum, Identity, Float(0)},
+		aggregate:       Aggregate{Sum, InverseSum, Identity, Float(0)},
 		branchingFactor: BRANCHING_FACTOR,
 	}
 	n0.tree = tree
@@ -505,7 +528,7 @@ func setupTree() *SegmentTreeImpl {
 
 	tree := &SegmentTreeImpl{
 		root:            n0,
-		aggregate:       Aggregate{Sum, Identity, Float(0)},
+		aggregate:       Aggregate{Sum, InverseSum, Identity, Float(0)},
 		branchingFactor: BRANCHING_FACTOR,
 	}
 
@@ -534,8 +557,8 @@ func TestSumDosageScenarioInsert(t *testing.T) {
 	n0.parent = nil
 	tree := &SegmentTreeImpl{
 		root:            n0,
-		aggregate:       Aggregate{Sum, Identity, Float(0)},
-		branchingFactor: 4,
+		aggregate:       Aggregate{Sum, InverseSum, Identity, Float(0)},
+		branchingFactor: BRANCHING_FACTOR,
 	}
 
 	n0.tree = tree
@@ -617,7 +640,7 @@ func TestSumDosageScenarioDelete(t *testing.T) {
 	n0.parent = nil
 	tree := &SegmentTreeImpl{
 		root:            n0,
-		aggregate:       Aggregate{Sum, Identity, Float(0)},
+		aggregate:       Aggregate{Sum, InverseSum, Identity, Float(0)},
 		branchingFactor: BRANCHING_FACTOR,
 	}
 	n0.tree = tree
@@ -678,4 +701,39 @@ func TestSumDosageScenarioDelete(t *testing.T) {
 	assert.Equal(Float(0), tree.root.values[0])
 	assert.Len(n0.children, 1)
 	assert.Nil(tree.root.children[0])
+}
+
+func TestInsertRange(t *testing.T) {
+	// Arrange
+	aggregate := Aggregate{Sum, InverseSum, Identity, Float(0)}
+
+	var testData []ValueIntervalTuple = []ValueIntervalTuple{
+		{interval: NewInterval(10, 40), value: Float(2)},
+		{interval: NewInterval(10, 30), value: Float(3)},
+		{interval: NewInterval(20, 40), value: Float(1)},
+		{interval: NewInterval(5, 15), value: Float(2)},
+		{interval: NewInterval(35, 45), value: Float(4)},
+		{interval: NewInterval(10, 50), value: Float(1)},
+	}
+
+	tree := NewSegmentTree(BRANCHING_FACTOR, aggregate)
+
+	// Act
+	tree.InsertRange(testData)
+
+	// Assert
+	result := tree.GetWithinInterval(NewInterval(0, math.MaxUint32))
+
+	assert.Len(t, result, 10)
+
+	assert.Equal(t, ValueIntervalTuple{interval: NewInterval(0, 5), value: Float(0)}, result[0])
+	assert.Equal(t, ValueIntervalTuple{interval: NewInterval(5, 10), value: Float(2)}, result[1])
+	assert.Equal(t, ValueIntervalTuple{interval: NewInterval(10, 15), value: Float(8)}, result[2])
+	assert.Equal(t, ValueIntervalTuple{interval: NewInterval(15, 20), value: Float(6)}, result[3])
+	assert.Equal(t, ValueIntervalTuple{interval: NewInterval(20, 30), value: Float(7)}, result[4])
+	assert.Equal(t, ValueIntervalTuple{interval: NewInterval(30, 35), value: Float(4)}, result[5])
+	assert.Equal(t, ValueIntervalTuple{interval: NewInterval(35, 40), value: Float(8)}, result[6])
+	assert.Equal(t, ValueIntervalTuple{interval: NewInterval(40, 45), value: Float(5)}, result[7])
+	assert.Equal(t, ValueIntervalTuple{interval: NewInterval(45, 50), value: Float(1)}, result[8])
+	assert.Equal(t, ValueIntervalTuple{interval: NewInterval(50, math.MaxUint32), value: Float(0)}, result[9])
 }

--- a/segmenttree/segmenttreeimpl.go
+++ b/segmenttree/segmenttreeimpl.go
@@ -13,7 +13,7 @@ func NewSegmentTree(branchingFactor uint32, aggregate Aggregate) *SegmentTreeImp
 	}
 
 	tree.root = tree.newNode()
-	tree.root.values = append(tree.root.values, Float(0))
+	tree.root.values = append(tree.root.values, aggregate.neutralElement)
 
 	return tree
 }

--- a/segmenttree/segmenttreeimpl.go
+++ b/segmenttree/segmenttreeimpl.go
@@ -1,11 +1,5 @@
 package segmenttree
 
-type Aggregate struct {
-	operation       func(Addable, Addable) Addable
-	additionElement func(Addable) Addable
-	neutralElement  Addable
-}
-
 type SegmentTreeImpl struct {
 	root            *Node
 	aggregate       Aggregate
@@ -19,16 +13,16 @@ func NewSegmentTree(branchingFactor uint32, aggregate Aggregate) *SegmentTreeImp
 	}
 
 	tree.root = tree.newNode()
-	tree.root.values[0] = Float(0)
+	tree.root.values = append(tree.root.values, Float(0))
 
 	return tree
 }
 
 func (t *SegmentTreeImpl) newNode() *Node {
 	node := &Node{
-		keys:     make([]uint32, t.branchingFactor+1),  // + 1 to account for an interval being split into three intervals
-		values:   make([]Addable, t.branchingFactor+2), // + 2 to account for an interval being split into three intervals
-		children: make([]*Node, t.branchingFactor+2),   // + 2 to account for an interval being split into three intervals
+		keys:     make([]uint32, 0, t.branchingFactor+1),  // + 1 to account for an interval being split into three intervals
+		values:   make([]Addable, 0, t.branchingFactor+2), // + 2 to account for an interval being split into three intervals
+		children: make([]*Node, 0, t.branchingFactor+2),   // + 2 to account for an interval being split into three intervals
 		isLeaf:   true,
 		parent:   nil,
 		tree:     t,
@@ -58,6 +52,23 @@ func (tree *SegmentTreeImpl) Delete(value ValueIntervalTuple) {
 
 	tree.insert(tree.root, ValueIntervalTuple{value: valueToInsert, interval: value.interval})
 
+}
+
+func (tree *SegmentTreeImpl) InsertRange(values []ValueIntervalTuple) {
+	if tree.root.size() > 0 {
+		panic("Cannot insert a range into a non-empty tree")
+	}
+
+	tuples := createAndSortValueTimeTuples(tree.aggregate, values)
+
+	currentValue := tree.aggregate.neutralElement
+
+	for _, tuple := range tuples {
+
+		currentValue = tree.aggregate.operation(currentValue, tuple.value)
+
+		tree.root.insertTuple(tuple.time, currentValue)
+	}
 }
 
 func (tree *SegmentTreeImpl) lookup(node *Node, instant uint32) Addable {

--- a/segmenttree/valuetimetuple.go
+++ b/segmenttree/valuetimetuple.go
@@ -1,0 +1,6 @@
+package segmenttree
+
+type ValueTimeTuple struct {
+	value Addable
+	time  uint32
+}


### PR DESCRIPTION
This is an implementation of bulk insertion.

It does not exactly implement the procedure described in the paper. But it uses some building blocks of it.

Basic idea:

- sort the incoming tuples and compact (eliminate tuples that neutralize each other, compact those that belong to the same timestamp)
- insert the tuples in order (always insert at the rightmost part of the tree)
